### PR TITLE
py3.x: Change range() to np.arange() 

### DIFF
--- a/pdpbox/info_plot_utils.py
+++ b/pdpbox/info_plot_utils.py
@@ -610,7 +610,7 @@ def _prepare_info_plot_data(feature, feature_type, data, num_grid_points, grid_t
 
     data_x['fake_count'] = 1
     bar_data = data_x.groupby('x', as_index=False).agg({'fake_count': 'count'}).sort_values('x', ascending=True)
-    summary_df = pd.DataFrame(range(data_x['x'].min(), data_x['x'].max() + 1), columns=['x'])
+    summary_df = pd.DataFrame(np.arange(data_x['x'].min(), data_x['x'].max() + 1), columns=['x'])
     summary_df = summary_df.merge(bar_data.rename(columns={'fake_count': 'count'}), on='x', how='left').fillna(0)
 
     summary_df['display_column'] = summary_df['x'].apply(lambda x: display_columns[int(x)])


### PR DESCRIPTION
pandas DataFrame constructor doesn't support iterators and `_prepare_info_plot_data` is using the built-in function `range` to create a DataFrame.

In python2, `range` creates a list of values but in python3 it creates an iterator, resulting in a failure when calling `target_plot`, that calls `_prepare_info_plot_data`.

There are many solutions for this but the chosen one is to replace `range` for `np.arange`, creating a numpy array instead.