### PR TITLE
Accepts a custom matplotlib.colors.Normalize object

### DIFF
--- a/pdpbox/pdp.py
+++ b/pdpbox/pdp.py
@@ -641,6 +641,8 @@ def pdp_interact_plot(pdp_interact_out, feature_names, plot_type='contour', x_qu
                 'inter_fill_alpha': 0.8,
                 # fontsize for interact plot text
                 'inter_fontsize': 9,
+                # custom matplotlib.colors.Normalize object used for normalizing 'marginal effect' color scale
+                'norm': None,
             }
 
     Returns
@@ -752,6 +754,7 @@ def pdp_interact_plot(pdp_interact_out, feature_names, plot_type='contour', x_qu
 
     _plot_title(title=title, subtitle=subtitle, title_ax=title_ax, plot_params=plot_params)
 
+    norm = plot_params.get('norm', None)
     inter_params = {'plot_type': plot_type, 'x_quantile': x_quantile, 'plot_params': plot_params}
     if num_charts == 1:
         feature_names_adj = feature_names
@@ -766,7 +769,7 @@ def pdp_interact_plot(pdp_interact_out, feature_names, plot_type='contour', x_qu
         else:
             inter_ax = plt.subplot(outer_grid[1])
             fig.add_subplot(inter_ax)
-            _pdp_inter_one(pdp_interact_out=pdp_interact_plot_data[0], inter_ax=inter_ax, norm=None,
+            _pdp_inter_one(pdp_interact_out=pdp_interact_plot_data[0], inter_ax=inter_ax, norm=norm,
                            feature_names=feature_names_adj, **inter_params)
     else:
         wspace = 0.3
@@ -788,7 +791,7 @@ def pdp_interact_plot(pdp_interact_out, feature_names, plot_type='contour', x_qu
                 inner_inter_ax = plt.subplot(inner_grid[inner_idx])
                 fig.add_subplot(inner_inter_ax)
                 _pdp_inter_one(pdp_interact_out=pdp_interact_plot_data[inner_idx], inter_ax=inner_inter_ax,
-                               norm=None, feature_names=feature_names_adj, **inter_params)
+                               norm=norm, feature_names=feature_names_adj, **inter_params)
             inter_ax.append(inner_inter_ax)
 
     axes = {'title_ax': title_ax, 'pdp_inter_ax': inter_ax}


### PR DESCRIPTION
In this PR, `pdpbox.pdp.pdp_interact_plot()` makes use of user specified (if any) `matplotlib.colors.Normalize` object as value for `'norm'` key in `'plot_params'` dictionary argument. A user initialized normalize object can be used & reused to obtain consistent normalization of 'marginal effect' being plotted. If this key is not set, the method is set to behave as unmodified version by passing `None` as norm to `_pdp_inter_one()`.

This PR was created to address [https://github.com/SauceCat/PDPbox/issues/39](https://github.com/SauceCat/PDPbox/issues/39)

Affect of this PR can be seen in following two plots. 
The 'Before' plots uses full color scale regardless of the range of 'marginal effect' being plotted.
In the 'After' plots, color mappings are consistent with values of the 'marginal effect' being plotted.

Interaction plots with large variations in marginal effects can now be identified with cursory look at 'After' plots, without having to read off range from color scale.

**Plot 1: Small Range of Marginal Effect**

Before:
![01_before_crop](https://user-images.githubusercontent.com/3257730/47311164-b9f35c00-d658-11e8-8032-89bd79059019.png)

After:
![01_after_crop](https://user-images.githubusercontent.com/3257730/47311172-beb81000-d658-11e8-9c9f-be1501225fb1.png)


**Plot 2: Large Range of Marginal Effect**

Before:
![02_before_crop](https://user-images.githubusercontent.com/3257730/47311190-cd9ec280-d658-11e8-9d23-b5eb03de5b54.png)

After:
![02_after_crop](https://user-images.githubusercontent.com/3257730/47311198-d2637680-d658-11e8-8d77-fbeca06e5f8b.png)