### PR TITLE
Include LICENSE.txt in sdist and wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include LICENSE.txt
 include versioneer.py
 include pdpbox/_version.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 description-file = README.md
+license_files = LICENSE.txt
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
It would be nice to include the license in release tarballs.