### PR TITLE
Replace sklearn with scikit-learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Update for versions:
 ```
 xgboost==1.3.3
 matplotlib==3.1.1
-sklearn==0.23.1
+scikit-learn==0.23.1
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(name='PDPbox',
           'joblib',
           'psutil',
           'matplotlib==3.1.1',
-          'sklearn'
+          'scikit-learn'
       ],
       zip_safe=False)

--- a/tutorials/pdpbox_binary_classification.ipynb
+++ b/tutorials/pdpbox_binary_classification.ipynb
@@ -27,7 +27,7 @@
     "# versions\n",
     "- `xgboost`: 1.3.3\n",
     "- `matplotlib`: 3.1.1\n",
-    "- `sklearn`: 0.23.1"
+    "- `scikit-learn`: 0.23.1"
    ]
   },
   {

--- a/tutorials/pdpbox_multiclass_classification.ipynb
+++ b/tutorials/pdpbox_multiclass_classification.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "# versions\n",
     "- `matplotlib`: 3.1.1\n",
-    "- `sklearn`: 0.23.1"
+    "- `scikit-learn`: 0.23.1"
    ]
   },
   {

--- a/tutorials/pdpbox_regression.ipynb
+++ b/tutorials/pdpbox_regression.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "# versions\n",
     "- `matplotlib`: 3.1.1\n",
-    "- `sklearn`: 0.23.1"
+    "- `scikit-learn`: 0.23.1"
    ]
   },
   {


### PR DESCRIPTION
The sklearn package is a wrapper around scikit-learn, and sklearn will be removed from PyPI at some point, starting with brownouts.

Instead, use scikit-learn directly.

See https://github.com/scikit-learn/scikit-learn/issues/8215 for more info.